### PR TITLE
Fix #5652 - Notify too short when abbrev in JA

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -403,8 +403,8 @@ ja:
         one: "新しい1件の通知 \U0001F418"
         other: "新しい%{count}件の通知 \U0001F418"
     favourite:
-      body: 'あなたのトゥートが %{name} さんにお気に入り登録されました:'
-      subject: "%{name} さんがあなたのトゥートをお気に入りに登録しました"
+      body: '%{name} さんにお気に入り登録された、あなたのトゥートがあります:'
+      subject: "%{name} さんにお気に入りに登録されました"
     follow:
       body: "%{name} さんにフォローされています"
       subject: "%{name} さんにフォローされています"
@@ -415,8 +415,8 @@ ja:
       body: "%{name} さんから返信がありました:"
       subject: "%{name} さんに返信されました"
     reblog:
-      body: 'あなたのトゥートが %{name} さんにブーストされました:'
-      subject: あなたのトゥートが %{name} さんにブーストされました
+      body: "%{name} さんにブーストされた、あなたのトゥートがあります:"
+      subject: "%{name} さんにブーストされました"
   number:
     human:
       decimal_units:


### PR DESCRIPTION
Fix #5652 of the notification message to be understandable when abbreviated.